### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Newsletter Analyzer
+
+This project contains a React frontend and a FastAPI backend. To deploy the frontend on **GitHub Pages** you can run:
+
+```bash
+cd frontend
+npm install
+npm run deploy
+```
+
+The `deploy` script builds the project and publishes the static files to the `gh-pages` branch so they can be served via GitHub Pages. The built files are also available in the `docs/` directory for simple "Pages" deployments from the repository root.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#ff5a1f" />
+    <meta
+      name="description"
+      content="Testez votre newsletter HTML en 30 secondes - Vérification des liens, analyse IA, prévisualisation responsive"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Newsletter Analyzer - Test rapide de newsletter HTML</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "newsletter-analyzer-frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
@@ -21,6 +22,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build -b gh-pages",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -45,7 +48,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
-    "tailwindcss": "^3.3.6"
+    "tailwindcss": "^3.3.6",
+    "gh-pages": "^5.0.0"
   },
   "proxy": "http://localhost:8001"
 }


### PR DESCRIPTION
## Summary
- add README with steps to deploy frontend on GitHub Pages
- configure `homepage`, `deploy` script, and add `gh-pages` dependency
- provide a `docs/index.html` placeholder for GitHub Pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r backend/requirements.txt` *(fails: Could not install packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687f3af3b3cc832a949cfa9496ba2640