### PR TITLE
Add GitHub Pages deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ npm run deploy
 ```
 
 The `deploy` script builds the project and publishes the static files to the `gh-pages` branch so they can be served via GitHub Pages. The built files are also available in the `docs/` directory for simple "Pages" deployments from the repository root.
+After running `npm run deploy`, visit your repository settings on GitHub. Under **Pages** choose "Deploy from a branch – gh-pages" to publish your site. It will be available at `https://<username>.github.io/<repo>/`.
+


### PR DESCRIPTION
## Summary
- document how to enable GitHub Pages after running `npm run deploy`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests bs4` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_687f3f70e084832a9efc7d84529a663e