### PR TITLE
Add postbuild script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "predeploy": "npm run build",
+    "postbuild": "cp -a build/* ../docs/",
     "deploy": "gh-pages -d build -b gh-pages",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Summary
- add a postbuild script in `frontend/package.json`

## Testing
- `python backend_test.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f416efe9c832ab6dcc6aba3ec9645